### PR TITLE
Update column names to escape reserved words

### DIFF
--- a/lib/table_saw/queries/prepared_insert_statement.rb
+++ b/lib/table_saw/queries/prepared_insert_statement.rb
@@ -31,7 +31,9 @@ module TableSaw
       end
 
       def column_names
-        TableSaw.schema_cache.columns(table_name).map(&:name).join(', ')
+        TableSaw.schema_cache.columns(table_name)
+          .map { |column| TableSaw.schema_cache.connection.quote_column_name(column.name) }
+          .join(', ')
       end
 
       def values_clause

--- a/spec/internal/db/schema.rb
+++ b/spec/internal/db/schema.rb
@@ -22,4 +22,9 @@ ActiveRecord::Schema.define(version: 0) do
   end
 
   create_view :popular_authors, materialized: true
+
+  create_table :magazines do |t|
+    t.string :title
+    t.string :from
+  end
 end

--- a/spec/table_saw/formats/insert_spec.rb
+++ b/spec/table_saw/formats/insert_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe TableSaw::Formats::Insert do
   describe '#header' do
     it 'returns prepared statement' do
       expect(formatter.header).to eq <<~SQL.squish
-        PREPARE authors_insert_plan (bigint, character varying) AS INSERT INTO authors (id, name) VALUES ($1, $2);
+        PREPARE authors_insert_plan (bigint, character varying) AS INSERT INTO authors ("id", "name") VALUES ($1, $2);
       SQL
     end
   end

--- a/spec/table_saw/queries/prepared_insert_statement_spec.rb
+++ b/spec/table_saw/queries/prepared_insert_statement_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe TableSaw::Queries::PreparedInsertStatement do
 
       it 'returns a prepared statement' do
         expect(query.call.sql).to eq <<~SQL.squish
-          PREPARE authors_insert_plan (bigint, character varying) AS INSERT INTO authors (id, name) VALUES ($1, $2);
+          PREPARE authors_insert_plan (bigint, character varying) AS INSERT INTO authors ("id", "name") VALUES ($1, $2);
         SQL
       end
     end
@@ -22,7 +22,7 @@ RSpec.describe TableSaw::Queries::PreparedInsertStatement do
 
       it 'returns prepared statement with do nothing on conflict' do
         expect(query.call.sql).to eq <<~SQL.squish
-          PREPARE authors_insert_plan (bigint, character varying) AS INSERT INTO authors (id, name) VALUES ($1, $2)
+          PREPARE authors_insert_plan (bigint, character varying) AS INSERT INTO authors ("id", "name") VALUES ($1, $2)
             ON CONFLICT DO NOTHING;
         SQL
       end
@@ -34,7 +34,18 @@ RSpec.describe TableSaw::Queries::PreparedInsertStatement do
       it 'returns a prepared statement' do
         expect(query.call.sql).to eq <<~SQL.squish
           PREPARE books_insert_plan (bigint, bigint, character varying, character varying[])
-            AS INSERT INTO books (id, author_id, name, tags) VALUES ($1, $2, $3, $4);
+            AS INSERT INTO books ("id", "author_id", "name", "tags") VALUES ($1, $2, $3, $4);
+        SQL
+      end
+    end
+
+    context 'when a column name is a reserved word' do
+      let(:table_name) { 'magazines' }
+
+      it 'returns a prepared statement' do
+        expect(query.call.sql).to eq <<~SQL.squish
+          PREPARE magazines_insert_plan (bigint, character varying, character varying)
+            AS INSERT INTO magazines ("id", "title", "from") VALUES ($1, $2, $3);
         SQL
       end
     end


### PR DESCRIPTION
While trying to pull down a table, there was
a column called 'from' that caused tablesaw to
break. this fixes that issue.