### PR TITLE
Create a new parameter to override manifest parameters

### DIFF
--- a/exe/table-saw
+++ b/exe/table-saw
@@ -25,6 +25,8 @@ class CLI < Thor
   method_option :manifest, aliases: '-m', required: true
   method_option :output, aliases: '-o', default: 'output.dump'
   method_option :format, type: :hash, default: { 'type' => 'copy' }
+  method_option :variables, aliases: '-v', type: :hash, default: {},
+                            desc: 'This option takes a hash to override variables provided in the manifest'
   def dump
     TableSaw.configure(options.to_hash)
     records = TableSaw::DependencyGraph::Build.new(TableSaw::Manifest.instance).call

--- a/lib/table_saw/configuration.rb
+++ b/lib/table_saw/configuration.rb
@@ -2,7 +2,7 @@
 
 module TableSaw
   class Configuration
-    attr_accessor :dbname, :host, :port, :user, :password, :manifest, :output, :format
+    attr_accessor :dbname, :host, :port, :user, :password, :manifest, :output, :format, :variables
 
     def connection
       { dbname: dbname, host: host, port: port, user: user, password: password }

--- a/lib/table_saw/manifest.rb
+++ b/lib/table_saw/manifest.rb
@@ -47,7 +47,8 @@ module TableSaw
     end
 
     def variables
-      config.fetch('variables', {})
+      vars = config.fetch('variables', {})
+      vars.merge(TableSaw.configuration.variables.slice(*vars.keys))
     end
 
     def tables


### PR DESCRIPTION
This allows people to pass in any subset of the manifest parameters to override with different values, if they desire.