### PR TITLE
feat: Add string interpolation to variables in manifest.yml

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    table_saw (2.10.0)
+    table_saw (2.11.0)
       activerecord (>= 5.2)
       pg
       thor

--- a/README.md
+++ b/README.md
@@ -100,6 +100,21 @@ tables:
     query: "select * from books where author_id = %{author_id}"
 ```
 
+Additionally, you can now use the `%{variable}` substitution pattern in subsequent variables:
+```yaml
+variables:
+  author_id: '1,3,4',
+  book_ids: 'select * from books where author_id in (%{author_id})' 
+```
+
+Note that only previously assigned variables can be substituted into subsequent variables, attempting to access a variable before it is declared like this:
+```yaml
+variables:
+  author_id: '%{book_ids}',
+  book_ids: 'select * from books limit 10'  
+```
+will result in incorrectly assembled queries (i.e. passing %{book_ids} into the SQL query.)
+
 #### tables
 This is where you list the specific tables that you want to export. If you only specify the `table` without providing a 
 `query`, then the **entire** table will be exported. However, if you specify a `query`, then only rows matching that 

--- a/lib/table_saw/version.rb
+++ b/lib/table_saw/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module TableSaw
-  VERSION = '2.10.0'
+  VERSION = '2.11.0'
 end


### PR DESCRIPTION
Similar to how table queries can be constructed using variable
stand-ins, to enhance understanding in a manifest.yml file we want to be
able to re use a variable inside the builder for another variable.
Example:

```yaml
variables:
  book_ids: '1,3,4,10'
  author_ids: 'select * from authors where book_id in (%{book_ids})'
```

Co-authored-by: Eric Wanchic <ewanchic@g2.com>

This allows two use cases that are not currently supported in table_saw:
1. The ability to semantically name variables (i.e. `illustrator_id` tied to a particular set of author_ids based on a query)
2. The ability to re-use one base set of IDs to drive the subsequent ids for other related tables. For a theoretical case of needing to acquire a set of authors by id, their books, publishers with this style:

```yaml
variables:
  author_ids: '1,2,4',
  book_ids: 'select * from books where author_id in (%{author_ids})',
  publishers: 'select * from publishers where author_id in (%{author_ids})'
...
```
Additionally, this change allows us to take advantage of the CLI variable reassignment when running a saw to customize it for a particular need `saw manifest.yml -a -v book_ids:4` while preserving the rest of the interpolation.