### PR TITLE
Primary Key for Foreign Tables

### DIFF
--- a/lib/table_saw.rb
+++ b/lib/table_saw.rb
@@ -30,4 +30,33 @@ module TableSaw
   def self.schema_cache
     TableSaw::Connection.adapter.schema_cache
   end
+
+  def self.primary_keys(manifest, table_name)
+    override_primary_key = look_for_primary_key(manifest, table_name)
+
+    if override_primary_key.present?
+      override_primary_key
+    else
+      schema_primary_keys = TableSaw.primary_keys(manifest, table_name)
+
+      raise ArgumentError, 'a primary_key: must be specified for foreign tables' unless schema_primary_keys.present?
+
+      schema_primary_keys
+    end
+  end
+
+  def self.look_for_primary_key(manifest, table_name)
+    suggested_primary_key = nil
+
+    manifest.tables.each_value do |table|
+      if table.name == table_name && table.primary_key.present?
+        suggested_primary_key = table.primary_key
+        next
+      end
+    end
+
+    suggested_primary_key
+  end
+
+  private_class_method :look_for_primary_key
 end

--- a/lib/table_saw/dependency_graph/add_directive.rb
+++ b/lib/table_saw/dependency_graph/add_directive.rb
@@ -3,10 +3,11 @@
 module TableSaw
   module DependencyGraph
     class AddDirective
-      attr_reader :table_name, :partial, :has_many
+      attr_reader :manifest, :table_name, :partial, :has_many
       attr_accessor :ids
 
-      def initialize(table_name, ids: [], partial: true, has_many: {})
+      def initialize(manifest, table_name, ids: [], partial: true, has_many: {})
+        @manifest = manifest
         @table_name = table_name
         @ids = ids
         @partial = partial
@@ -24,7 +25,7 @@ module TableSaw
       end
 
       def primary_key
-        TableSaw.schema_cache.primary_keys(table_name)
+        TableSaw.primary_keys(manifest, table_name)
       end
     end
   end

--- a/lib/table_saw/dependency_graph/build_has_many_query.rb
+++ b/lib/table_saw/dependency_graph/build_has_many_query.rb
@@ -25,7 +25,7 @@ module TableSaw
 
       # rubocop:disable Metrics/AbcSize
       def build_base_query
-        format(QUERY, primary_key: TableSaw.schema_cache.primary_keys(foreign_key.from_table),
+        format(QUERY, primary_key: TableSaw.primary_keys(manifest, foreign_key.from_table),
                       table: foreign_key.from_table,
                       clause: TableSaw::Queries::SerializeSqlInClause.new(foreign_key.from_table,
                                                                           foreign_key.column.primary_key,

--- a/lib/table_saw/dependency_graph/dump_table.rb
+++ b/lib/table_saw/dependency_graph/dump_table.rb
@@ -39,7 +39,7 @@ module TableSaw
       end
 
       def primary_key
-        TableSaw.schema_cache.primary_keys(name)
+        TableSaw.primary_keys(manifest, name)
       end
     end
   end

--- a/lib/table_saw/dependency_graph/has_many_directives.rb
+++ b/lib/table_saw/dependency_graph/has_many_directives.rb
@@ -14,7 +14,7 @@ module TableSaw
         valid_associations.map do |fk|
           TableSaw::DependencyGraph::AddDirective.new(
             fk.from_table,
-            ids: query_result(fk).map { |r| r[TableSaw.schema_cache.primary_keys(fk.from_table)] },
+            ids: query_result(fk).map { |r| r[TableSaw.primary_keys(manifest, fk.from_table)] },
             partial: directive.partial?
           )
         end

--- a/lib/table_saw/manifest.rb
+++ b/lib/table_saw/manifest.rb
@@ -54,6 +54,10 @@ module TableSaw
         format(config['query'], variables.transform_keys(&:to_sym))
       end
 
+      def primary_key
+        config['primary_key']
+      end
+
       def partial?
         config.key?('query')
       end


### PR DESCRIPTION
ActiveRecord, is unable to detect primary keys on foreign tables in postgresql.

The optional feature primary_key: has been added to override the nil results ActiveRecord gives for primary keys.

Argument Errors are also provided for the user.